### PR TITLE
Implement CRUD endpoints for articles

### DIFF
--- a/src/articles/articles.controller.js
+++ b/src/articles/articles.controller.js
@@ -16,6 +16,59 @@ class ArticlesController {
         res.status(500).json({ message: 'Error retrieving articles', error })
       })
   }
+
+  create(req, res) {
+    articlesService
+      .create(req.body)
+      .then((article) => {
+        res.status(201).json(article)
+      })
+      .catch((error) => {
+        res.status(500).json({ message: 'Error creating article', error })
+      })
+  }
+
+  findOne(req, res) {
+    articlesService
+      .findOne(req.params.id)
+      .then((article) => {
+        if (!article) {
+          return res.status(404).json({ message: 'Article not found' })
+        }
+        res.status(200).json(article)
+      })
+      .catch((error) => {
+        res.status(500).json({ message: 'Error retrieving article', error })
+      })
+  }
+
+  update(req, res) {
+    articlesService
+      .update(req.params.id, req.body)
+      .then((article) => {
+        if (!article) {
+          return res.status(404).json({ message: 'Article not found' })
+        }
+        res.status(200).json(article)
+      })
+      .catch((error) => {
+        res.status(500).json({ message: 'Error updating article', error })
+      })
+  }
+
+  delete(req, res) {
+    articlesService
+      .delete(req.params.id)
+      .then((article) => {
+        if (!article) {
+          return res.status(404).json({ message: 'Article not found' })
+        }
+        res.status(200).json({ message: 'Article deleted successfully' })
+      })
+      .catch((error) => {
+        res.status(500).json({ message: 'Error deleting article', error })
+      })
+  }
 }
 
 module.exports = new ArticlesController()

--- a/src/articles/articles.router.js
+++ b/src/articles/articles.router.js
@@ -1,9 +1,20 @@
 //article router.js
 const express = require('express')
 const router = express.Router()
-const { test, findAll } = require('./articles.controller')
+const {
+  test,
+  findAll,
+  create,
+  findOne,
+  update,
+  delete: deleteArticle,
+} = require('./articles.controller')
 
 // Define the routes for articles
 router.get('/test', test)
 router.get('/', findAll)
+router.post('/', create)
+router.get('/:id', findOne)
+router.put('/:id', update)
+router.delete('/:id', deleteArticle)
 module.exports = router

--- a/src/articles/articles.service.js
+++ b/src/articles/articles.service.js
@@ -10,5 +10,26 @@ class ArticlesService {
       order: [['createdAt', 'DESC']],
     })
   }
+
+  async create(data) {
+    return await db.database.Articles.create(data)
+  }
+
+  async findOne(id) {
+    return await db.database.Articles.findByPk(id)
+  }
+
+  async update(id, data) {
+    const article = await db.database.Articles.findByPk(id)
+    if (!article) return null
+    return await article.update(data)
+  }
+
+  async delete(id) {
+    const article = await db.database.Articles.findByPk(id)
+    if (!article) return null
+    await article.destroy()
+    return article
+  }
 }
 module.exports = new ArticlesService()


### PR DESCRIPTION
## Summary
- extend article service with create, findOne, update, delete
- expose new controller methods for CRUD operations
- wire up REST routes for article endpoints

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851818ed3a08323bfd2158fc13b6cd6