### PR TITLE
Add user model and auth routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+DB_HOST=localhost
+DB_USER=user
+DB_PASSWORD=pass
+DB_PORT=5432
+DB_NAME=database
+JWT_SECRET=your_secret_key

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
+        "bcrypt": "^5.1.1",
+        "jsonwebtoken": "^9.0.0",
         "pg": "^8.16.0",
         "sequelize": "^6.37.7"
       },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "bcrypt": "^5.1.1",
+    "jsonwebtoken": "^9.0.0",
     "pg": "^8.16.0",
     "sequelize": "^6.37.7"
   },

--- a/src/articles/articles.controller.js
+++ b/src/articles/articles.controller.js
@@ -18,8 +18,12 @@ class ArticlesController {
   }
 
   create(req, res) {
+    if (!req.user) {
+      return res.status(401).json({ message: 'Unauthorized' })
+    }
+    const data = { ...req.body, userId: req.user.id }
     articlesService
-      .create(req.body)
+      .create(data)
       .then((article) => {
         res.status(201).json(article)
       })

--- a/src/models/init-models.js
+++ b/src/models/init-models.js
@@ -1,10 +1,17 @@
 const DataTypes = require('sequelize').DataTypes
 const articles = require('./articles')
+const users = require('./users')
 
 function initModels(sequelize) {
   const Articles = articles(sequelize, DataTypes)
+  const Users = users(sequelize, DataTypes)
+
+  Users.hasMany(Articles, { foreignKey: 'userId' })
+  Articles.belongsTo(Users, { foreignKey: 'userId' })
+
   return {
     Articles,
+    Users,
   }
 }
 module.exports = initModels

--- a/src/models/users.js
+++ b/src/models/users.js
@@ -1,27 +1,27 @@
 module.exports = function (sequelize, DataTypes) {
-  const Articles = sequelize.define(
-    'articles',
+  const Users = sequelize.define(
+    'users',
     {
       id: {
         type: DataTypes.INTEGER,
         primaryKey: true,
         autoIncrement: true,
       },
-      title: {
+      name: {
         type: DataTypes.STRING,
         allowNull: false,
       },
-      content: {
-        type: DataTypes.TEXT,
+      email: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: true,
+      },
+      password: {
+        type: DataTypes.STRING,
         allowNull: false,
       },
-      userId: {
-        type: DataTypes.INTEGER,
-        allowNull: false,
-        references: {
-          model: 'users',
-          key: 'id',
-        },
+      address: {
+        type: DataTypes.STRING,
       },
       createdAt: {
         type: DataTypes.DATE,
@@ -33,10 +33,10 @@ module.exports = function (sequelize, DataTypes) {
       },
     },
     {
-      tableName: 'articles',
+      tableName: 'users',
       timestamps: true,
     },
   )
 
-  return Articles
+  return Users
 }

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,6 +1,8 @@
 const express = require('express')
 const router = express.Router()
 const article = require('../articles/articles.router')
+const users = require('../users/users.router')
 router.use('/articles', article)
+router.use('/users', users)
 
 module.exports = router

--- a/src/users/users.controller.js
+++ b/src/users/users.controller.js
@@ -1,0 +1,35 @@
+const usersService = require('./users.service')
+const bcrypt = require('bcrypt')
+const jwt = require('jsonwebtoken')
+
+class UsersController {
+  async register(req, res) {
+    try {
+      const user = await usersService.register(req.body)
+      res.status(201).json(user)
+    } catch (error) {
+      res.status(500).json({ message: 'Error registering user', error })
+    }
+  }
+
+  async login(req, res) {
+    try {
+      const user = await usersService.findByEmail(req.body.email)
+      if (!user) return res.status(401).json({ message: 'Invalid credentials' })
+
+      const valid = await bcrypt.compare(req.body.password, user.password)
+      if (!valid) return res.status(401).json({ message: 'Invalid credentials' })
+
+      const token = jwt.sign(
+        { id: user.id },
+        process.env.JWT_SECRET || 'secret',
+        { expiresIn: '1h' },
+      )
+      res.status(200).json({ token })
+    } catch (error) {
+      res.status(500).json({ message: 'Error logging in', error })
+    }
+  }
+}
+
+module.exports = new UsersController()

--- a/src/users/users.router.js
+++ b/src/users/users.router.js
@@ -1,0 +1,8 @@
+const express = require('express')
+const router = express.Router()
+const { register, login } = require('./users.controller')
+
+router.post('/register', register)
+router.post('/login', login)
+
+module.exports = router

--- a/src/users/users.service.js
+++ b/src/users/users.service.js
@@ -1,0 +1,20 @@
+const bcrypt = require('bcrypt')
+const db = require('../models')
+
+class UsersService {
+  async register(data) {
+    const hashedPassword = await bcrypt.hash(data.password, 10)
+    return await db.database.Users.create({
+      name: data.name,
+      email: data.email,
+      password: hashedPassword,
+      address: data.address,
+    })
+  }
+
+  async findByEmail(email) {
+    return await db.database.Users.findOne({ where: { email } })
+  }
+}
+
+module.exports = new UsersService()


### PR DESCRIPTION
## Summary
- create `Users` model and user CRUD for register/login
- link `Articles` to `Users`
- add auth controller/service and routes
- include JWT secret example and new dependencies

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685a658eb2948323babce45d09114d49